### PR TITLE
fix(live): workarround cast attribute

### DIFF
--- a/resources/lib/indexers/live.py
+++ b/resources/lib/indexers/live.py
@@ -55,6 +55,8 @@ def get_channels():
             'content': 'tvshows',    # 'content': 'tvshows',  # content: files, songs, artists, albums, movies, tvshows, episodes, musicvideos
             'mediatype': 'episode',  # 'mediatype': "video", "movie", "tvshow", "season", "episode" or "musicvideo"
         })
+        if channel.get('cast') is None:
+            channel['cast'] = []
         properties = channel.get('properties', {})
         if not properties:
             channel['properties'] = properties


### PR DESCRIPTION
Sometimes the cast attribute comes as None and the live channel list doesn't appear.